### PR TITLE
Drafted a Flask web version.

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,11 @@
+run = "python app.py"
+modules = ["python-3.10"]
+
+[nix]
+channel = "stable-22_11"
+
+[deployment]
+run = ["sh", "-c", "python app.py"]
+
+[env]
+PYTHONPATH = "${REPL_HOME}"

--- a/README_WEBAPP.md
+++ b/README_WEBAPP.md
@@ -1,0 +1,312 @@
+# 🌐 Poker Settlement Tracker - Web Application
+
+A modern web-based version of the Poker Settlement Tracker, featuring RESTful APIs and an intuitive HTML/JavaScript frontend.
+
+## 🚀 Features
+
+### Web Interface
+- **Responsive Design**: Bootstrap-based UI that works on desktop and mobile
+- **Real-time Updates**: Instant table updates after each action
+- **Interactive Forms**: Easy-to-use forms for all poker operations
+- **Visual Feedback**: Toast notifications and color-coded balances
+- **Settlement Visualization**: Clear display of transfers and balances
+
+### API Endpoints
+- **Game Management**: Start games, get current game status
+- **Player Operations**: Buy-in, payments, cash-out, payouts
+- **Data Analysis**: Summary statistics and settlement calculations
+- **Data Export**: CSV export functionality
+- **Historical Data**: Access to previous games
+
+## 📋 Prerequisites
+
+- Python 3.7+
+- pip (Python package installer)
+
+## 🛠️ Installation
+
+1. **Clone the repository** (if not already done):
+   ```bash
+   git clone https://github.com/danielqq000/poker_settle.git
+   cd poker_settle
+   ```
+
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## 🎮 Usage
+
+### Starting the Web Application
+
+1. **Run the Flask server**:
+   ```bash
+   python app.py
+   ```
+
+2. **Open your browser** and navigate to:
+   ```
+   http://localhost:5000
+   ```
+
+### Using the Web Interface
+
+#### 1. Start a Game
+- Enter a date in MM/DD format (e.g., "08/01")
+- Click "Start Game"
+- The current game will be displayed
+
+#### 2. Player Actions
+- **Buy In**: Enter player name and amount, click "Buy In"
+- **Payment**: Record cash or Zelle payments from players
+- **Cash Out**: Record when players cash out chips
+- **Payout**: Record cash or Zelle payouts to players
+
+#### 3. Game Management
+- **Summary**: View total buy-ins, payments, cash-outs, and bank balance
+- **Solve**: Calculate optimal settlement transfers
+- **Export**: Export current game data to CSV
+- **Save**: Manually save current game state
+
+#### 4. Settlement Analysis
+The "Solve" feature provides:
+- Individual player balances
+- Minimum number of transfers needed
+- Step-by-step transfer instructions
+- Final bank balance verification
+
+## 🔌 API Reference
+
+### Game Endpoints
+
+#### Start Game
+```http
+POST /api/game/start
+Content-Type: application/json
+
+{
+  "date": "08/01"
+}
+```
+
+#### Get Current Game
+```http
+GET /api/game/current
+```
+
+### Player Endpoints
+
+#### Buy In
+```http
+POST /api/players/buy-in
+Content-Type: application/json
+
+{
+  "name": "Alice",
+  "amount": 100
+}
+```
+
+#### Record Payment
+```http
+POST /api/players/payment
+Content-Type: application/json
+
+{
+  "name": "Alice",
+  "amount": 50,
+  "method": "cash"
+}
+```
+
+#### Cash Out
+```http
+POST /api/players/cash-out
+Content-Type: application/json
+
+{
+  "name": "Alice",
+  "amount": 75
+}
+```
+
+#### Record Payout
+```http
+POST /api/players/payout
+Content-Type: application/json
+
+{
+  "name": "Alice",
+  "amount": 25,
+  "method": "zelle"
+}
+```
+
+#### Remove Player
+```http
+DELETE /api/players/remove
+Content-Type: application/json
+
+{
+  "name": "Alice"
+}
+```
+
+### Data Endpoints
+
+#### Get Table Data
+```http
+GET /api/table
+```
+
+#### Get Summary
+```http
+GET /api/summary
+```
+
+#### Calculate Settlement
+```http
+GET /api/solve
+```
+
+#### Get Historical Data
+```http
+GET /api/history/08/01
+```
+
+#### Export Data
+```http
+GET /api/export
+```
+
+#### Save Game
+```http
+POST /api/save
+```
+
+#### Clear Game
+```http
+POST /api/clear
+```
+
+## 🏗️ Architecture
+
+### Backend (Flask)
+- **app.py**: Main Flask application with RESTful API endpoints
+- **settle/tracker.py**: Core business logic (unchanged from CLI version)
+- **SQLite Database**: Persistent data storage in `data/settle.db`
+
+### Frontend
+- **templates/index.html**: Single-page application with Bootstrap UI
+- **JavaScript**: Async API calls with fetch() and DOM manipulation
+- **Bootstrap 5**: Responsive CSS framework
+- **Font Awesome**: Icons for better UX
+
+### Key Design Decisions
+1. **RESTful API**: Clean separation between frontend and backend
+2. **Single Page App**: All functionality on one page for simplicity
+3. **Real-time Updates**: Table refreshes after each operation
+4. **Error Handling**: Toast notifications for user feedback
+5. **Responsive Design**: Works on desktop and mobile devices
+
+## 📊 Data Flow
+
+1. **User Action** → Frontend JavaScript
+2. **API Call** → Flask Backend
+3. **Business Logic** → tracker.py functions
+4. **Database Update** → SQLite
+5. **Response** → JSON data back to frontend
+6. **UI Update** → DOM manipulation and visual feedback
+
+## 🔧 Development
+
+### Project Structure
+```
+poker_settle/
+├── app.py                 # Flask web server
+├── requirements.txt       # Python dependencies
+├── templates/
+│   └── index.html        # Web interface
+├── settle/
+│   └── tracker.py        # Core logic (unchanged)
+├── data/
+│   └── settle.db         # SQLite database
+├── run.py                # Original CLI entry point
+└── README_WEBAPP.md      # This file
+```
+
+### Adding New Features
+
+1. **Backend**: Add new endpoints in `app.py`
+2. **Frontend**: Add UI elements and JavaScript functions in `index.html`
+3. **Core Logic**: Extend functionality in `settle/tracker.py` if needed
+
+### Testing
+
+The web application maintains full compatibility with the original CLI version:
+- Same database structure
+- Same business logic
+- Same settlement algorithm
+- Data can be accessed via both interfaces
+
+## 🚀 Deployment
+
+### Development
+```bash
+python app.py
+# Server runs on http://localhost:5000
+```
+
+### Production
+For production deployment, consider:
+- Using a WSGI server like Gunicorn
+- Setting up a reverse proxy (nginx)
+- Using environment variables for configuration
+- Implementing proper logging and monitoring
+
+Example with Gunicorn:
+```bash
+pip install gunicorn
+gunicorn -w 4 -b 0.0.0.0:5000 app:app
+```
+
+## 🔒 Security Considerations
+
+- **Input Validation**: All API endpoints validate input data
+- **Error Handling**: Proper error responses without exposing internals
+- **CORS**: Configured for cross-origin requests if needed
+- **SQL Injection**: Using parameterized queries via SQLite
+
+For production use, consider adding:
+- Authentication and authorization
+- Rate limiting
+- HTTPS encryption
+- Input sanitization
+- Session management
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Test both CLI and web interfaces
+5. Submit a pull request
+
+## 📝 License
+
+Same as the original project - feel free to use and modify for your poker games!
+
+## 🎯 Future Enhancements
+
+- **Multi-game Management**: Switch between different games
+- **Player Profiles**: Store player information and history
+- **Game Templates**: Predefined buy-in amounts and structures
+- **Real-time Collaboration**: Multiple users managing the same game
+- **Mobile App**: Native mobile application
+- **Advanced Analytics**: Charts and statistics over time
+- **Backup/Restore**: Cloud backup functionality
+
+---
+
+**Enjoy your poker nights with the new web interface! 🃏💰**

--- a/app.py
+++ b/app.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+
+from flask import Flask, request, jsonify, render_template, send_from_directory
+from flask_cors import CORS
+import os
+import sys
+
+# Add the current directory to Python path to import settle module
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from settle import tracker
+
+app = Flask(__name__, static_folder='static', template_folder='templates')
+CORS(app)
+
+# Initialize database
+tracker.init_db()
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/api/game/start', methods=['POST'])
+def start_game():
+    """Start a new game with a specific date"""
+    try:
+        data = request.get_json()
+        date_str = data.get('date')
+        if not date_str:
+            return jsonify({'error': 'Date is required'}), 400
+        
+        tracker.start_game(date_str)
+        return jsonify({'message': f'Game started for {date_str}', 'date': date_str})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/game/current', methods=['GET'])
+def get_current_game():
+    """Get current game date and table data"""
+    try:
+        return jsonify({
+            'current_date': tracker.current_date,
+            'table': tracker.table
+        })
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/players/buy-in', methods=['POST'])
+def buy_in():
+    """Player buy-in"""
+    try:
+        data = request.get_json()
+        name = data.get('name')
+        amount = data.get('amount')
+        
+        if not name or amount is None:
+            return jsonify({'error': 'Name and amount are required'}), 400
+        
+        tracker.buy_in(name, amount)
+        tracker.save_table()
+        return jsonify({'message': f'{name} bought in for {amount}', 'table': tracker.table})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/players/payment', methods=['POST'])
+def payment():
+    """Record player payment"""
+    try:
+        data = request.get_json()
+        name = data.get('name')
+        amount = data.get('amount')
+        method = data.get('method')
+        
+        if not name or amount is None or not method:
+            return jsonify({'error': 'Name, amount, and method are required'}), 400
+        
+        if method not in ['cash', 'zelle']:
+            return jsonify({'error': 'Method must be cash or zelle'}), 400
+        
+        tracker.payment(name, amount, method)
+        tracker.save_table()
+        return jsonify({'message': f'{name} paid {amount} via {method}', 'table': tracker.table})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/players/cash-out', methods=['POST'])
+def cash_out():
+    """Record player cash out"""
+    try:
+        data = request.get_json()
+        name = data.get('name')
+        amount = data.get('amount')
+        
+        if not name or amount is None:
+            return jsonify({'error': 'Name and amount are required'}), 400
+        
+        tracker.cash_out(name, amount)
+        tracker.save_table()
+        return jsonify({'message': f'{name} cashed out {amount}', 'table': tracker.table})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/players/payout', methods=['POST'])
+def payout():
+    """Record player payout"""
+    try:
+        data = request.get_json()
+        name = data.get('name')
+        amount = data.get('amount')
+        method = data.get('method')
+        
+        if not name or amount is None or not method:
+            return jsonify({'error': 'Name, amount, and method are required'}), 400
+        
+        if method not in ['cash', 'zelle']:
+            return jsonify({'error': 'Method must be cash or zelle'}), 400
+        
+        tracker.pay_out(name, amount, method)
+        tracker.save_table()
+        return jsonify({'message': f'{name} received payout of {amount} via {method}', 'table': tracker.table})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/players/remove', methods=['DELETE'])
+def remove_player():
+    """Remove a player from the table"""
+    try:
+        data = request.get_json()
+        name = data.get('name')
+        
+        if not name:
+            return jsonify({'error': 'Name is required'}), 400
+        
+        tracker.remove_player(name)
+        tracker.save_table()
+        return jsonify({'message': f'{name} removed from table', 'table': tracker.table})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/table', methods=['GET'])
+def get_table():
+    """Get current table data"""
+    try:
+        return jsonify({'table': tracker.table, 'current_date': tracker.current_date})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/summary', methods=['GET'])
+def get_summary():
+    """Get game summary"""
+    try:
+        if not tracker.table:
+            return jsonify({'error': 'No data available'}), 400
+        
+        total_buy_in = sum(d["buy_in"] for d in tracker.table.values())
+        total_cash_out = sum(d["cash_out"] for d in tracker.table.values())
+        total_payment = sum(d["cash"] + d["zelle"] for d in tracker.table.values())
+        total_payout = sum(d["payout_cash"] + d["payout_zelle"] for d in tracker.table.values())
+        bank_balance = total_buy_in - total_cash_out - total_payment + total_payout
+        
+        return jsonify({
+            'total_buy_in': total_buy_in,
+            'total_cash_out': total_cash_out,
+            'total_payment': total_payment,
+            'total_payout': total_payout,
+            'bank_balance': bank_balance
+        })
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/solve', methods=['GET'])
+def solve():
+    """Calculate settlement transfers"""
+    try:
+        if not tracker.table:
+            return jsonify({'error': 'No data available'}), 400
+        
+        # Calculate balances
+        balances = {}
+        total_payment = 0
+        total_payout = 0
+        total_buy_in = 0
+        total_cash_out = 0
+
+        for name, record in tracker.table.items():
+            payment_cash = record.get("cash", 0)
+            payment_zelle = record.get("zelle", 0)
+            payout_cash = record.get("payout_cash", 0)
+            payout_zelle = record.get("payout_zelle", 0)
+            buy_in = record.get("buy_in", 0)
+            cash_out = record.get("cash_out", 0)
+
+            payment_total = payment_cash + payment_zelle
+            payout_total = payout_cash + payout_zelle
+
+            balance = -buy_in + payment_total + cash_out - payout_total
+            balances[name] = int(round(balance))
+
+            total_payment += payment_total
+            total_payout += payout_total
+            total_buy_in += buy_in
+            total_cash_out += cash_out
+
+        # Bank balance
+        bank_balance = total_buy_in - total_cash_out - total_payment + total_payout
+        balances["bank"] = int(round(bank_balance))
+
+        # Find minimum transactions using DFS
+        name_list = list(balances.keys())
+        combined = [(name, amt) for name, amt in balances.items()]
+
+        min_tx = float('inf')
+        best_transactions = []
+        memo = {}
+
+        def dfs(state, current):
+            nonlocal min_tx, best_transactions
+
+            state.sort(key=lambda x: (x[1] >= 0, -abs(x[1])))
+
+            start = 0
+            while start < len(state) and state[start][1] == 0:
+                start += 1
+
+            if start == len(state):
+                if len(current) < min_tx:
+                    min_tx = len(current)
+                    best_transactions = current[:]
+                return
+
+            state_key = tuple(x[1] for x in state)
+            if state_key in memo and memo[state_key] <= len(current):
+                return
+            memo[state_key] = len(current)
+
+            pos = sum(1 for _, amt in state[start:] if amt > 0)
+            neg = sum(1 for _, amt in state[start:] if amt < 0)
+            min_remaining = max(pos, neg)
+            if len(current) + min_remaining >= min_tx:
+                return
+
+            for i in range(start + 1, len(state)):
+                if state[start][1] * state[i][1] < 0:
+                    amt = min(abs(state[start][1]), abs(state[i][1]))
+                    original_start = state[start][1]
+                    original_i = state[i][1]
+
+                    if state[start][1] < 0:
+                        current.append((state[start][0], state[i][0], amt))
+                        state[start] = (state[start][0], state[start][1] + amt)
+                        state[i] = (state[i][0], state[i][1] - amt)
+                    else:
+                        current.append((state[i][0], state[start][0], amt))
+                        state[start] = (state[start][0], state[start][1] - amt)
+                        state[i] = (state[i][0], state[i][1] + amt)
+
+                    dfs([x[:] if isinstance(x, list) else list(x) for x in state], current)
+
+                    current.pop()
+                    state[start] = (state[start][0], original_start)
+                    state[i] = (state[i][0], original_i)
+
+                    if original_start + original_i == 0:
+                        break
+
+        dfs([list(x) for x in combined], [])
+
+        # Update balances after transfers
+        final_balances = balances.copy()
+        for payer, receiver, amount in best_transactions:
+            final_balances[payer] += amount
+            final_balances[receiver] -= amount
+
+        # Get non-zero balances (excluding bank)
+        missing_balances = {name: bal for name, bal in final_balances.items() 
+                          if name != "bank" and bal != 0}
+
+        return jsonify({
+            'balances': balances,
+            'transactions': [{'payer': t[0], 'receiver': t[1], 'amount': t[2]} 
+                           for t in best_transactions],
+            'missing_balances': missing_balances,
+            'final_bank_balance': abs(final_balances["bank"])
+        })
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/history/<date_str>', methods=['GET'])
+def get_history(date_str):
+    """Get historical data for a specific date"""
+    try:
+        # Save current state
+        current_date_backup = tracker.current_date
+        current_table_backup = tracker.table.copy()
+        
+        # Load historical data
+        tracker.current_date = date_str
+        tracker.load_table()
+        
+        result = {
+            'date': date_str,
+            'table': tracker.table.copy()
+        }
+        
+        # Restore current state
+        tracker.current_date = current_date_backup
+        tracker.table = current_table_backup
+        
+        return jsonify(result)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/export', methods=['GET'])
+def export_csv():
+    """Export current game data to CSV"""
+    try:
+        if not tracker.current_date:
+            return jsonify({'error': 'No active game'}), 400
+        
+        tracker.export_csv()
+        filename = tracker.current_date.replace("/", "_") + ".csv"
+        return jsonify({'message': f'Data exported to {filename}', 'filename': filename})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/save', methods=['POST'])
+def save_game():
+    """Save current game data"""
+    try:
+        if not tracker.current_date:
+            return jsonify({'error': 'No active game'}), 400
+        
+        tracker.save_table()
+        return jsonify({'message': f'{tracker.current_date} game saved'})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/clear', methods=['POST'])
+def clear_game():
+    """Clear current game data"""
+    try:
+        if not tracker.current_date:
+            return jsonify({'error': 'No active game'}), 400
+        
+        date_backup = tracker.current_date
+        tracker.save_table()
+        tracker.clear()
+        tracker.current_date = None
+        return jsonify({'message': f'{date_backup} game saved and cleared'})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.3.3
+Flask-CORS==4.0.0

--- a/settle/tracker.py
+++ b/settle/tracker.py
@@ -5,6 +5,9 @@ import csv
 import os
 
 db_path = os.path.join("data", "settle.db")
+db_dir = os.path.dirname(db_path)
+os.makedirs(db_dir, exist_ok=True)
+
 current_date = None
 table = {}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,554 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Poker Settlement Tracker</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        .card-header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+        .btn-poker {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            border: none;
+            color: white;
+        }
+        .btn-poker:hover {
+            background: linear-gradient(135deg, #764ba2 0%, #667eea 100%);
+            color: white;
+        }
+        .table-container {
+            max-height: 400px;
+            overflow-y: auto;
+        }
+        .balance-positive {
+            color: #28a745;
+            font-weight: bold;
+        }
+        .balance-negative {
+            color: #dc3545;
+            font-weight: bold;
+        }
+        .balance-zero {
+            color: #6c757d;
+        }
+        .settlement-card {
+            background: #f8f9fa;
+            border-left: 4px solid #28a745;
+        }
+        .summary-card {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+        }
+    </style>
+</head>
+<body class="bg-light">
+    <div class="container-fluid py-4">
+        <div class="row">
+            <div class="col-12">
+                <h1 class="text-center mb-4">
+                    <i class="fas fa-coins text-warning"></i>
+                    Poker Settlement Tracker
+                </h1>
+            </div>
+        </div>
+
+        <!-- Game Control -->
+        <div class="row mb-4">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="mb-0"><i class="fas fa-play"></i> Game Control</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-8">
+                                <input type="text" id="gameDate" class="form-control" placeholder="MM/DD (e.g., 08/01)">
+                            </div>
+                            <div class="col-4">
+                                <button class="btn btn-poker w-100" onclick="startGame()">
+                                    <i class="fas fa-play"></i> Start Game
+                                </button>
+                            </div>
+                        </div>
+                        <div class="mt-2">
+                            <small class="text-muted">Current Game: <span id="currentGame">None</span></small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="mb-0"><i class="fas fa-tools"></i> Actions</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="btn-group w-100" role="group">
+                            <button class="btn btn-outline-success" onclick="showSummary()">
+                                <i class="fas fa-chart-bar"></i> Summary
+                            </button>
+                            <button class="btn btn-outline-primary" onclick="calculateSettlement()">
+                                <i class="fas fa-calculator"></i> Solve
+                            </button>
+                            <button class="btn btn-outline-warning" onclick="exportData()">
+                                <i class="fas fa-download"></i> Export
+                            </button>
+                            <button class="btn btn-outline-info" onclick="saveGame()">
+                                <i class="fas fa-save"></i> Save
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Player Actions -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="mb-0"><i class="fas fa-user-plus"></i> Player Actions</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <!-- Buy In -->
+                            <div class="col-md-3">
+                                <div class="input-group">
+                                    <input type="text" id="buyInName" class="form-control" placeholder="Name">
+                                    <input type="number" id="buyInAmount" class="form-control" placeholder="Amount">
+                                    <button class="btn btn-success" onclick="buyIn()">
+                                        <i class="fas fa-plus"></i> Buy In
+                                    </button>
+                                </div>
+                            </div>
+                            <!-- Payment -->
+                            <div class="col-md-3">
+                                <div class="input-group">
+                                    <input type="text" id="paymentName" class="form-control" placeholder="Name">
+                                    <input type="number" id="paymentAmount" class="form-control" placeholder="Amount">
+                                    <select id="paymentMethod" class="form-select">
+                                        <option value="cash">Cash</option>
+                                        <option value="zelle">Zelle</option>
+                                    </select>
+                                    <button class="btn btn-primary" onclick="recordPayment()">
+                                        <i class="fas fa-credit-card"></i> Payment
+                                    </button>
+                                </div>
+                            </div>
+                            <!-- Cash Out -->
+                            <div class="col-md-3">
+                                <div class="input-group">
+                                    <input type="text" id="cashOutName" class="form-control" placeholder="Name">
+                                    <input type="number" id="cashOutAmount" class="form-control" placeholder="Amount">
+                                    <button class="btn btn-warning" onclick="cashOut()">
+                                        <i class="fas fa-money-bill"></i> Cash Out
+                                    </button>
+                                </div>
+                            </div>
+                            <!-- Payout -->
+                            <div class="col-md-3">
+                                <div class="input-group">
+                                    <input type="text" id="payoutName" class="form-control" placeholder="Name">
+                                    <input type="number" id="payoutAmount" class="form-control" placeholder="Amount">
+                                    <select id="payoutMethod" class="form-select">
+                                        <option value="cash">Cash</option>
+                                        <option value="zelle">Zelle</option>
+                                    </select>
+                                    <button class="btn btn-info" onclick="recordPayout()">
+                                        <i class="fas fa-hand-holding-usd"></i> Payout
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Current Table -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="mb-0"><i class="fas fa-table"></i> Current Table</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-container">
+                            <table class="table table-striped table-hover">
+                                <thead class="table-dark">
+                                    <tr>
+                                        <th>Name</th>
+                                        <th>Buy In</th>
+                                        <th>Payment (Cash+Zelle)</th>
+                                        <th>Cash Out</th>
+                                        <th>Payout (Cash+Zelle)</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="tableBody">
+                                    <tr>
+                                        <td colspan="6" class="text-center text-muted">No players yet</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Summary and Settlement -->
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card summary-card" id="summaryCard" style="display: none;">
+                    <div class="card-header bg-warning">
+                        <h5 class="mb-0 text-dark"><i class="fas fa-chart-pie"></i> Game Summary</h5>
+                    </div>
+                    <div class="card-body" id="summaryContent">
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card settlement-card" id="settlementCard" style="display: none;">
+                    <div class="card-header bg-success">
+                        <h5 class="mb-0"><i class="fas fa-exchange-alt"></i> Settlement</h5>
+                    </div>
+                    <div class="card-body" id="settlementContent">
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Toast Container -->
+    <div class="toast-container position-fixed bottom-0 end-0 p-3">
+        <div id="toast" class="toast" role="alert">
+            <div class="toast-header">
+                <strong class="me-auto">Notification</strong>
+                <button type="button" class="btn-close" data-bs-dismiss="toast"></button>
+            </div>
+            <div class="toast-body" id="toastBody">
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        const API_BASE = '/api';
+        let currentGameDate = null;
+
+        // Initialize page
+        document.addEventListener('DOMContentLoaded', function() {
+            loadCurrentGame();
+        });
+
+        // Utility functions
+        function showToast(message, type = 'info') {
+            const toast = document.getElementById('toast');
+            const toastBody = document.getElementById('toastBody');
+            const toastHeader = toast.querySelector('.toast-header');
+            
+            toastHeader.className = `toast-header bg-${type} text-white`;
+            toastBody.textContent = message;
+            
+            const bsToast = new bootstrap.Toast(toast);
+            bsToast.show();
+        }
+
+        function clearInputs(prefix) {
+            document.querySelectorAll(`input[id^="${prefix}"]`).forEach(input => {
+                input.value = '';
+            });
+            document.querySelectorAll(`select[id^="${prefix}"]`).forEach(select => {
+                select.selectedIndex = 0;
+            });
+        }
+
+        // API calls
+        async function apiCall(endpoint, method = 'GET', data = null) {
+            try {
+                const options = {
+                    method,
+                    headers: {
+                        'Content-Type': 'application/json',
+                    }
+                };
+                
+                if (data) {
+                    options.body = JSON.stringify(data);
+                }
+                
+                const response = await fetch(API_BASE + endpoint, options);
+                const result = await response.json();
+                
+                if (!response.ok) {
+                    throw new Error(result.error || 'API call failed');
+                }
+                
+                return result;
+            } catch (error) {
+                showToast(error.message, 'danger');
+                throw error;
+            }
+        }
+
+        // Game functions
+        async function startGame() {
+            const date = document.getElementById('gameDate').value.trim();
+            if (!date) {
+                showToast('Please enter a date (MM/DD)', 'warning');
+                return;
+            }
+            
+            try {
+                const result = await apiCall('/game/start', 'POST', { date });
+                currentGameDate = result.date;
+                document.getElementById('currentGame').textContent = result.date;
+                document.getElementById('gameDate').value = '';
+                showToast(result.message, 'success');
+                loadTable();
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        async function loadCurrentGame() {
+            try {
+                const result = await apiCall('/game/current');
+                currentGameDate = result.current_date;
+                document.getElementById('currentGame').textContent = result.current_date || 'None';
+                if (result.current_date) {
+                    loadTable();
+                }
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        async function loadTable() {
+            try {
+                const result = await apiCall('/table');
+                updateTableDisplay(result.table);
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        function updateTableDisplay(table) {
+            const tbody = document.getElementById('tableBody');
+            
+            if (!table || Object.keys(table).length === 0) {
+                tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">No players yet</td></tr>';
+                return;
+            }
+            
+            tbody.innerHTML = '';
+            
+            for (const [name, data] of Object.entries(table)) {
+                const row = document.createElement('tr');
+                const paymentTotal = data.cash + data.zelle;
+                const payoutTotal = data.payout_cash + data.payout_zelle;
+                
+                row.innerHTML = `
+                    <td><strong>${name}</strong></td>
+                    <td>$${data.buy_in}</td>
+                    <td>$${paymentTotal} (${data.cash}+${data.zelle})</td>
+                    <td>$${data.cash_out}</td>
+                    <td>$${payoutTotal} (${data.payout_cash}+${data.payout_zelle})</td>
+                    <td>
+                        <button class="btn btn-sm btn-outline-danger" onclick="removePlayer('${name}')">
+                            <i class="fas fa-trash"></i>
+                        </button>
+                    </td>
+                `;
+                tbody.appendChild(row);
+            }
+        }
+
+        // Player actions
+        async function buyIn() {
+            const name = document.getElementById('buyInName').value.trim();
+            const amount = parseInt(document.getElementById('buyInAmount').value);
+            
+            if (!name || !amount) {
+                showToast('Please enter name and amount', 'warning');
+                return;
+            }
+            
+            try {
+                const result = await apiCall('/players/buy-in', 'POST', { name, amount });
+                showToast(result.message, 'success');
+                updateTableDisplay(result.table);
+                clearInputs('buyIn');
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        async function recordPayment() {
+            const name = document.getElementById('paymentName').value.trim();
+            const amount = parseInt(document.getElementById('paymentAmount').value);
+            const method = document.getElementById('paymentMethod').value;
+            
+            if (!name || !amount) {
+                showToast('Please enter name and amount', 'warning');
+                return;
+            }
+            
+            try {
+                const result = await apiCall('/players/payment', 'POST', { name, amount, method });
+                showToast(result.message, 'success');
+                updateTableDisplay(result.table);
+                clearInputs('payment');
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        async function cashOut() {
+            const name = document.getElementById('cashOutName').value.trim();
+            const amount = parseInt(document.getElementById('cashOutAmount').value);
+            
+            if (!name || !amount) {
+                showToast('Please enter name and amount', 'warning');
+                return;
+            }
+            
+            try {
+                const result = await apiCall('/players/cash-out', 'POST', { name, amount });
+                showToast(result.message, 'success');
+                updateTableDisplay(result.table);
+                clearInputs('cashOut');
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        async function recordPayout() {
+            const name = document.getElementById('payoutName').value.trim();
+            const amount = parseInt(document.getElementById('payoutAmount').value);
+            const method = document.getElementById('payoutMethod').value;
+            
+            if (!name || !amount) {
+                showToast('Please enter name and amount', 'warning');
+                return;
+            }
+            
+            try {
+                const result = await apiCall('/players/payout', 'POST', { name, amount, method });
+                showToast(result.message, 'success');
+                updateTableDisplay(result.table);
+                clearInputs('payout');
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        async function removePlayer(name) {
+            if (!confirm(`Are you sure you want to remove ${name}?`)) {
+                return;
+            }
+            
+            try {
+                const result = await apiCall('/players/remove', 'DELETE', { name });
+                showToast(result.message, 'success');
+                updateTableDisplay(result.table);
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        // Summary and settlement
+        async function showSummary() {
+            try {
+                const result = await apiCall('/summary');
+                const summaryCard = document.getElementById('summaryCard');
+                const summaryContent = document.getElementById('summaryContent');
+                
+                summaryContent.innerHTML = `
+                    <div class="row">
+                        <div class="col-6">
+                            <p><strong>Total Buy In:</strong> $${result.total_buy_in}</p>
+                            <p><strong>Total Payment:</strong> $${result.total_payment}</p>
+                        </div>
+                        <div class="col-6">
+                            <p><strong>Total Cash Out:</strong> $${result.total_cash_out}</p>
+                            <p><strong>Total Payout:</strong> $${result.total_payout}</p>
+                        </div>
+                    </div>
+                    <hr>
+                    <p class="text-center"><strong>Bank Balance: $${result.bank_balance}</strong></p>
+                `;
+                
+                summaryCard.style.display = 'block';
+                showToast('Summary updated', 'info');
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        async function calculateSettlement() {
+            try {
+                const result = await apiCall('/solve');
+                const settlementCard = document.getElementById('settlementCard');
+                const settlementContent = document.getElementById('settlementContent');
+                
+                let content = '<h6>Player Balances:</h6><ul class="list-unstyled">';
+                for (const [name, balance] of Object.entries(result.balances)) {
+                    const balanceClass = balance > 0 ? 'balance-positive' : balance < 0 ? 'balance-negative' : 'balance-zero';
+                    content += `<li><span class="${balanceClass}">${name}: $${balance}</span></li>`;
+                }
+                content += '</ul>';
+                
+                if (result.transactions.length > 0) {
+                    content += '<h6>Settlement Transfers:</h6><ul class="list-unstyled">';
+                    result.transactions.forEach(tx => {
+                        content += `<li><i class="fas fa-arrow-right text-success"></i> ${tx.payer} pays ${tx.receiver} <strong>$${tx.amount}</strong></li>`;
+                    });
+                    content += '</ul>';
+                } else {
+                    content += '<p class="text-muted">No transfers needed</p>';
+                }
+                
+                if (Object.keys(result.missing_balances).length > 0) {
+                    content += '<h6>Remaining Balances:</h6><ul class="list-unstyled">';
+                    for (const [name, balance] of Object.entries(result.missing_balances)) {
+                        const balanceClass = balance > 0 ? 'balance-positive' : 'balance-negative';
+                        content += `<li><span class="${balanceClass}">${name}: $${balance}</span></li>`;
+                    }
+                    content += '</ul>';
+                }
+                
+                content += `<hr><p class="text-center"><strong>Final Bank Balance: $${result.final_bank_balance}</strong></p>`;
+                
+                settlementContent.innerHTML = content;
+                settlementCard.style.display = 'block';
+                showToast('Settlement calculated', 'success');
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        async function exportData() {
+            try {
+                const result = await apiCall('/export');
+                showToast(result.message, 'success');
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+
+        async function saveGame() {
+            try {
+                const result = await apiCall('/save', 'POST');
+                showToast(result.message, 'success');
+            } catch (error) {
+                // Error already shown in apiCall
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This is the draft of a Flask web version. It's currently running on Replit. You can try it out via the link I gave you earlier.
By the way, `app.py` can also serve as the API backend for a Discord bot while still maintaining the web interface. 

I guess some adjustment of directory structure and code modularization need to be done first, before we can further improve the features. Here's my suggestion:
```
poker_settle/
├── app.py                # Flask app code
├── requirements.txt
├── templates/          # Flask page
│   └── *.html
├── static/                 # Flask page static resources
│   ├── css/
│   ├── js/
│   └── images/
├── settle/                 # Business logic module
│   └── tracker.py           # I can help further abstract the database logic so that we can change to other type of storage
└── data/
    └── *.db
```